### PR TITLE
Add filter against Prototype Pollution

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -312,14 +312,14 @@ function iterateQueryString(queryString, callback) {
   var keyValues = queryString.split('&');
   _.each(keyValues, function(keyValue) {
     var arr = keyValue.split('=');
-    if (!containsInvalidKey(keyValue)) {
+    if (!containsInvalidKey(arr[0])) {
       callback(arr.shift(), arr.join('='));
     }
   });
 }
 
-function containsInvalidKey(key) {
-  return INVALID_KEYS.some(invalidKey => key.includes(invalidKey));
+function containsInvalidKey(keys) {
+  return INVALID_KEYS.some(invalidKey => keys.includes(invalidKey));
 }
 
 }));

--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -13,6 +13,9 @@
    }
 }(this, function(_, Backbone) {
 
+// Prevent against Prototype Pollution: https://blog.sonatype.com/how-can-adversaries-exploit-npm-modules
+const INVALID_KEYS = ['__proto__', 'constructor'];
+
 var queryStringParam = /^\?(.*)/,
     optionalParam = /\((.*?)\)/g,
     namedParam    = /(\(\?)?:\w+/g,
@@ -309,8 +312,14 @@ function iterateQueryString(queryString, callback) {
   var keyValues = queryString.split('&');
   _.each(keyValues, function(keyValue) {
     var arr = keyValue.split('=');
-    callback(arr.shift(), arr.join('='));
+    if (!containsInvalidKey(keyValue)) {
+      callback(arr.shift(), arr.join('='));
+    }
   });
+}
+
+function containsInvalidKey(key) {
+  return INVALID_KEYS.some(invalidKey => key.includes(invalidKey));
 }
 
 }));

--- a/readme.md
+++ b/readme.md
@@ -64,3 +64,9 @@ If you want to use this plugin with regex routes you'll need to append the query
 should be written
 
     router.route(/foo\/([^\/]+)\/([\?]{1}.*)?/, 'foo:event', callback)
+
+Prevention Against Prototype Pollution
+-------------------------
+Note that the keywords `__proto__` and `constructor` won't be allowed as key in the query parameters for security reason.
+
+If you want to learn more about Prototype Pollution: https://blog.sonatype.com/how-can-adversaries-exploit-npm-modules

--- a/test/backbone.query.params-test.js
+++ b/test/backbone.query.params-test.js
@@ -327,11 +327,12 @@ $(document).ready(function() {
   });
 
   test("Prevent against Prototype Pollution", 1, function() {
-    var route = 'search/nyc/p10?__proto__.test=test&foo=bar%20%3A%20baz&foo.bar=test&constructor.prototype.test=test',
+    var route = 'search/nyc/p10?__proto__.polluted=foo&constructor.prototype.polluted=bar&bar=constructor&foo=bar&foobar',
         params = Backbone.history.getQueryParameters(route);
     deepEqual(params, {
-      "foo": "bar : baz",
-      "foo.bar": "test"
+      "bar": "constructor",
+      "foo": "bar",
+      "foobar": ""
     });
   })
 });

--- a/test/backbone.query.params-test.js
+++ b/test/backbone.query.params-test.js
@@ -325,4 +325,13 @@ $(document).ready(function() {
     equal(match[1], 'foo');
     equal(match[2], undefined);
   });
+
+  test("Prevent against Prototype Pollution", 1, function() {
+    var route = 'search/nyc/p10?__proto__.test=test&foo=bar%20%3A%20baz&foo.bar=test&constructor.prototype.test=test',
+        params = Backbone.history.getQueryParameters(route);
+    deepEqual(params, {
+      "foo": "bar : baz",
+      "foo.bar": "test"
+    });
+  })
 });


### PR DESCRIPTION
Prevents against Prototype Pollution vulnerability by filtering sensitive keywords to be used as key in the query parameters: `__proto__` and `constructor`.

More information about Prototype Pollution here: https://blog.sonatype.com/how-can-adversaries-exploit-npm-modules 