### PR TITLE
Add regex against square brackets to bypass prototype pollution filter

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -353,18 +353,18 @@ function iterateQueryString(queryString, callback) {
   var keyValues = queryString.split('&');
   _.each(keyValues, function(keyValue) {
     var arr = keyValue.split('=');
-    if (!containsInvalidKey(arr[0])) {
+    if (!isInvalidKey(arr[0])) {
       callback(arr.shift(), arr.join('='));
     }
   });
 }
 
-function containsInvalidKey(keys) {
+function isInvalidKey(key) {
   // Square brackets will be removed down the line so
   // we want to make sure they are filtered upfront.
   var regex = /(\[|\])+/gi;
-  var sanitizedKeys = keys.replace(regex, '');
-  return INVALID_KEYS.some(invalidKey => sanitizedKeys.includes(invalidKey));
+  var sanitizedKey = key.replace(regex, '');
+  return INVALID_KEYS.some(invalidKey => sanitizedKey.includes(invalidKey));
 }
 
 }));

--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -14,7 +14,7 @@
 }(this, function(_, Backbone) {
 
 // Prevent against Prototype Pollution: https://blog.sonatype.com/how-can-adversaries-exploit-npm-modules
-const INVALID_KEYS = ['__proto__', 'constructor'];
+var INVALID_KEYS = ['__proto__', 'constructor'];
 
 var queryStringParam = /^\?(.*)/,
     optionalParam = /\((.*?)\)/g,
@@ -362,7 +362,7 @@ function iterateQueryString(queryString, callback) {
 function containsInvalidKey(keys) {
   // Square brackets will be removed down the line so
   // we want to make sure they are filtered upfront.
-  const regex = /(\[|\])+/gi;
+  var regex = /(\[|\])+/gi;
   var sanitizedKeys = keys.replace(regex, '');
   return INVALID_KEYS.some(invalidKey => sanitizedKeys.includes(invalidKey));
 }

--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -360,7 +360,11 @@ function iterateQueryString(queryString, callback) {
 }
 
 function containsInvalidKey(keys) {
-  return INVALID_KEYS.some(invalidKey => keys.includes(invalidKey));
+  // Square brackets will be removed down the line so
+  // we want to make sure they are filtered upfront.
+  const regex = /(\[|\])+/gi;
+  var sanitizedKeys = keys.replace(regex, '');
+  return INVALID_KEYS.some(invalidKey => sanitizedKeys.includes(invalidKey));
 }
 
 }));

--- a/test/backbone.query.params-test.js
+++ b/test/backbone.query.params-test.js
@@ -335,4 +335,14 @@ $(document).ready(function() {
       "foobar": ""
     });
   })
+
+  test("Prevent against Prototype Pollution (bypassing filter when using square brackets)", 1, function() {
+    var route = 'search/nyc/p10?__pr]o[]to__.polluted=foo&c]ons[]tr[uc]tor.prototype.polluted=bar&bar=constructor&foo=bar&foobar',
+        params = Backbone.history.getQueryParameters(route);
+    deepEqual(params, {
+      "bar": "constructor",
+      "foo": "bar",
+      "foobar": ""
+    });
+  })
 });


### PR DESCRIPTION
It is currently possible to bypass the filter against prototype pollution using square brackets in the key passed int he URL.

This is because square brackets are replaced in the function _setParamValue() on line 230:
`key = key.replace('[]', '');`

This PR adds a filter to the validator against square brackets to make sure the invalid keywords are detected properly. 