### PR TITLE
Updated version to 0.2.2-atlassian-1 instead of 0.2.2 so that Snyk can ignore this version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-query-parameters",
-  "version": "0.2.2",
+  "version": "0.2.2-atlassian-1",
   "description": "Backbone plugin which provides query parameter support for Backbone.Router",
   "main": "backbone.queryparams.js",
   "dependencies": {


### PR DESCRIPTION
This is needed to differentiate this backbone-query-parameters fork from the NPM version which has a VULN. @yannkechichian @aaaa0441